### PR TITLE
Don't add task-list class to lists that have no tasks

### DIFF
--- a/lib/task_list/filter.rb
+++ b/lib/task_list/filter.rb
@@ -54,7 +54,7 @@ class TaskList
 
     class XPathSelectorFunction
       def self.task_list_item(nodes)
-        nodes if nodes.text =~ ItemPattern
+        nodes.select { |node| node.text =~ ItemPattern }
       end
     end
 
@@ -95,12 +95,13 @@ class TaskList
         item.source.sub(ItemPattern, render_item_checkbox(item)), 'utf-8'
     end
 
-    # Public: Select all task lists from the `doc`.
+    # Public: Select all task list items within `container`.
     #
     # Returns an Array of Nokogiri::XML::Element objects for ordered and
-    # unordered lists.
-    def list_items
-      doc.xpath(ListItemSelector, XPathSelectorFunction)
+    # unordered lists. The container can either be the entire document (as
+    # returned by `#doc`) or an Element object.
+    def list_items(container)
+      container.xpath(ListItemSelector, XPathSelectorFunction)
     end
 
     # Filters the source for task list items.
@@ -112,7 +113,9 @@ class TaskList
     #
     # Returns nothing.
     def filter!
-      list_items.reverse.each do |li|
+      list_items(doc).reverse.each do |li|
+        next if list_items(li.parent).empty?
+
         add_css_class(li.parent, 'task-list')
 
         outer, inner =

--- a/test/task_list/filter_test.rb
+++ b/test/task_list/filter_test.rb
@@ -13,6 +13,14 @@ class TaskList::FilterTest < Minitest::Test
     @item_selector = "input.task-list-item-checkbox[type=checkbox]"
   end
 
+  def test_has_no_effect_on_lists_with_no_tasks
+    text = <<-md
+- plain
+- bullets
+    md
+    assert_equal 0, filter(text)[:output].css('ul.task-list').size
+  end
+
   def test_filters_items_in_a_list
     text = <<-md
 - [ ] incomplete


### PR DESCRIPTION
_From @gma on Apr 20, 2015_

Markdown documents can contain multiple lists, some of which might
contain tasks, and some which might not.

Prior to this commit the HTML::Pipeline::TaskList filter added the
'task-list' CSS class to all lists if at least one contained an item
that looked like a task. This made it impossible to style task lists
differently to other lists in the document.

_Copied from original merge request https://github.com/github-archive/task_list/pull/58_

_Fixes #8_