### PR TITLE
Don't Update Code Blocks

### DIFF
--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -135,7 +135,8 @@ itemPattern = ///
   )
 ///
 
-# Used to filter out code fences from the source for comparison only.
+# Used to skip checkbox markup inside of code fences.
+# http://rubular.com/r/TfCDNsy8x4
 startFencesPattern = /^`{3}.*$/
 endFencesPattern = /^`{3}$/
 
@@ -161,9 +162,12 @@ updateTaskListItem = (source, itemIndex, checked) ->
   inCodeBlock = false
   result = for line in source.split("\n")
     if inCodeBlock
+      # Lines inside of a code block are ignored.
       if line.match(endFencesPattern)
+        # Stop ignoring lines once the code block is closed.
         inCodeBlock = false
     else if line.match(startFencesPattern)
+      # Start ignoring lines inside a code block.
       inCodeBlock = true
     else if line in clean && line.match(itemPattern)
       index += 1

--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -136,16 +136,8 @@ itemPattern = ///
 ///
 
 # Used to filter out code fences from the source for comparison only.
-# http://rubular.com/r/x5EwZVrloI
-# Modified slightly due to issues with JS
-codeFencesPattern = ///
-  ^`{3}           # ```
-    (?:\s*\w+)?   # followed by optional language
-    [\S\s]        # whitespace
-  .*              # code
-  [\S\s]          # whitespace
-  ^`{3}$          # ```
-///mg
+startFencesPattern = /^`{3}.*$/
+endFencesPattern = /^`{3}$/
 
 # Used to filter out potential mismatches (items not in lists).
 # http://rubular.com/r/OInl6CiePy
@@ -164,11 +156,16 @@ itemsInParasPattern = ///
 #
 # Returns the updated String text.
 updateTaskListItem = (source, itemIndex, checked) ->
-  clean = source.replace(/\r/g, '').replace(codeFencesPattern, '').
-    replace(itemsInParasPattern, '').split("\n")
+  clean = source.replace(/\r/g, '').replace(itemsInParasPattern, '').split("\n")
   index = 0
+  inCodeBlock = false
   result = for line in source.split("\n")
-    if line in clean && line.match(itemPattern)
+    if inCodeBlock
+      if line.match(endFencesPattern)
+        inCodeBlock = false
+    else if line.match(startFencesPattern)
+      inCodeBlock = true
+    else if line in clean && line.match(itemPattern)
       index += 1
       if index == itemIndex
         line =

--- a/test/unit/test_updates.coffee
+++ b/test/unit/test_updates.coffee
@@ -564,3 +564,69 @@ asyncTest "updates items followed by links", ->
   , 20
 
   item2Checkbox.click()
+
+asyncTest "doesn't update items inside code blocks", ->
+  expect 3
+
+  container = $ '<div>', class: 'js-task-list-container'
+
+  list = $ '<ul>', class: 'task-list'
+
+  item1 = $ '<li>', class: 'task-list-item'
+  item1Checkbox = $ '<input>',
+    type: 'checkbox'
+    class: 'task-list-item-checkbox'
+    disabled: true
+    checked: false
+
+  item2 = $ '<li>', class: 'task-list-item'
+  item2Checkbox = $ '<input>',
+    type: 'checkbox'
+    class: 'task-list-item-checkbox'
+    disabled: true
+    checked: false
+
+  field = $ '<textarea>', class: 'js-task-list-field', text: """
+    ```
+    - [ ] test1
+    - [ ] test2
+    ```
+
+    - [ ] test1
+    - [ ] test2
+  """
+
+  changes = """
+    ```
+    - [ ] test1
+    - [ ] test2
+    ```
+
+    - [ ] test1
+    - [x] test2
+  """
+
+  item1.append item1Checkbox
+  list.append item1
+  item1.expectedIndex = 1
+
+  item2.append item2Checkbox
+  list.append item2
+  item2.expectedIndex = 2
+
+  container.append list
+  container.append field
+
+  $('#qunit-fixture').append(container)
+  container.taskList()
+
+  field.on 'tasklist:changed', (event, index, checked) =>
+    ok checked
+    equal index, item2.expectedIndex
+    equal field.val(), changes
+
+  setTimeout ->
+    start()
+  , 20
+
+  item2Checkbox.click()

--- a/test/unit/test_updates.coffee
+++ b/test/unit/test_updates.coffee
@@ -565,6 +565,7 @@ asyncTest "updates items followed by links", ->
 
   item2Checkbox.click()
 
+# See https://github.com/deckar01/task_list/issues/3
 asyncTest "doesn't update items inside code blocks", ->
   expect 3
 


### PR DESCRIPTION
Prevent updates from modifying list items inside code blocks. Ignore lines inside code blocks during the scan instead of trying to remove all code blocks with a regex before the scan.

Fixes #3