### PR TITLE
Drop support for link spaces

### DIFF
--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -190,14 +190,7 @@ class TaskList
       #{@escapePattern(@complete)}|
       #{@escapePattern(@incomplete)}
     )
-    \s+                     # is followed by whitespace
-    (?!
-      \(.*?\)               # is not part of a [foo](url) link
-    )
-    (?=                     # and is followed by zero or more links
-      (?:\[.*?\]\s*(?:\[.*?\]|\(.*?\))\s*)*
-      (?:[^\[]|$)           # and either a non-link or the end of the string
-    )
+    \s                      # is followed by whitespace
   ///
 
   # Used to skip checkbox markup inside of code fences.

--- a/test/unit/test_updates.coffee
+++ b/test/unit/test_updates.coffee
@@ -466,20 +466,20 @@ asyncTest "update ignores items that look like Task List items but are links", -
     checked: false
 
   field = $ '<textarea>', class: 'js-task-list-field', text: """
-    - [ ] (link)
-    - [ ] [reference]
-    - [ ] () collapsed
-    - [ ] [] collapsed reference
-    - [ ] \\(escaped item)
+    - [ ](link)
+    - [ ][reference]
+    - [ ]() collapsed
+    - [ ][] collapsed reference
+    - [ ] (no longer a link)
     - [ ] item
   """
 
   changes = """
-    - [ ] (link)
-    - [ ] [reference]
-    - [ ] () collapsed
-    - [ ] [] collapsed reference
-    - [ ] \\(escaped item)
+    - [ ](link)
+    - [ ][reference]
+    - [ ]() collapsed
+    - [ ][] collapsed reference
+    - [ ] (no longer a link)
     - [x] item
   """
 


### PR DESCRIPTION
Fixes #4 

Drop support for the `[text] (url)` and `[text] [ref]` markdown syntax. This syntax was already incompatible with the task list syntax, so dropping support for it is considered a bug fix.

The common mark spec does not allow this optional link spacing and this library's primary user (GitLab) recently dropped support for it.