### PR TITLE
Fix PhantomJS Tests on Linux

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "description": "Markdown TaskList components",
   "homepage": "https://github.com/deckar01/task_list",
   "devDependencies": {
-    "jquery": ">= 1.9.1",
+    "jquery": ">= 1.9.1 <3",
     "qunit": "^1.0.0",
     "rails-behaviors": "^0.8.4"
   },

--- a/test/run-qunit.coffee
+++ b/test/run-qunit.coffee
@@ -1,5 +1,4 @@
 fs = require 'fs'
-print = (s) -> fs.write "/dev/stderr", s, 'w'
 
 page = new WebPage()
 page.onConsoleMessage = (msg) -> console.error msg
@@ -29,7 +28,7 @@ page.open phantom.args[0], ->
     return unless tests
     for test in tests when test
       deferTimeout()
-      print test
+      console.error test
 
     result = page.evaluate ->
       result = document.getElementById('qunit-testresult')


### PR DESCRIPTION
The tests started failing due to a an open ended version range on the jQuery bower dev dependency.

- Avoid `/dev/stderr` in favor of `console.error`
- Avoid jQuery 3 since it does not support the phantomjs binary for linux platforms