### PR TITLE
Ignore task items that are empty

### DIFF
--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -238,7 +238,7 @@ class TaskList
       else if line.match(@startFencesPattern)
         # Start ignoring lines inside a code block.
         inCodeBlock = true
-      else if line in clean && line.match(@itemPattern)
+      else if line in clean && line.trim().match(@itemPattern)
         index += 1
         if index == itemIndex
           lineNumber = i + 1

--- a/test/functional/test_task_lists_behavior.html
+++ b/test/functional/test_task_lists_behavior.html
@@ -73,6 +73,9 @@
   <div class="js-task-list-container js-task-list-enable">
     <div class="markdown">
       <ul class="task-list">
+        <li>
+          [ ]
+        </li>
         <li class="task-list-item">
           <input type="checkbox" class="task-list-item-checkbox" disabled />
           I'm a task list item
@@ -93,6 +96,7 @@
     </div>
     <form action="/update" method="POST" data-remote data-type="json">
       <textarea name="comment[body]" class="js-task-list-field" cols="40" rows="10">
+- [ ]  
 - [ ] I'm a task list item
 - [ ] with non-breaking space
 - [x] completed, lower


### PR DESCRIPTION
GFM does note recognize empty tasks as valid task items.  For example:

- [ ]
- [ ] one
- [ ] two

However when using `task_list`, clicking on the `one` task would try to change the empty task.

I've updated the regex to ignore empty task items.