### PR TITLE
Use 'sourcepos' information when available

### DIFF
--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -150,7 +150,7 @@ class TaskList
 
     unless changeEvent.defaultPrevented
       { result, lineNumber, lineSource } =
-        TaskList.updateSource(@field.value, index, item)
+        TaskList.updateSource(@field.value, index, item.checked, item)
 
       @field.value = result
       changeEvent = createEvent 'change'
@@ -220,54 +220,65 @@ class TaskList
   # given checked value.
   #
   # Returns the updated String text.
-  @updateSource: (source, itemIndex, item) ->
-    checked = item.checked
-    split_source = source.split("\n")
+  @updateSource: (source, itemIndex, checked, item) ->
+    if item.parentElement.hasAttribute('data-sourcepos')
+      @_updateSourcePosition(source, item, checked)
+    else
+      @_updateSourceRegex(source, itemIndex, checked)
+
+  # If we have sourcepos information, that tells us which line the task
+  # is on without the need for parsing
+  @_updateSourcePosition: (source, item, checked) ->
+    result = source.split("\n")
     sourcepos = item.parentElement.getAttribute('data-sourcepos')
+    lineNumber = parseInt(sourcepos.split(":")[0])
+    lineSource = result[lineNumber - 1]
+
+    line =
+      if checked
+        lineSource.replace(@incompletePattern, @complete)
+      else
+        lineSource.replace(@completePattern, @incomplete)
+
+    result[lineNumber - 1] = line
+
+    return {
+      result: result.join("\n")
+      lineNumber: lineNumber
+      lineSource: lineSource
+    }
+
+  @_updateSourceRegex: (source, itemIndex, checked) ->
+    split_source = source.split("\n")
     lineNumber
     lineSource
 
-    if sourcepos
-      # If we have sourcepos information, that tells us
-      # which line the task is on without the need for parsing
-      result = split_source
-      lineNumber = parseInt(sourcepos.split(":")[0])
-      lineSource = result[lineNumber - 1]
+    clean = source.replace(/\r/g, '').
+      replace(@itemsInParasPattern, '').
+      split("\n")
+    index = 0
+    inCodeBlock = false
 
-      line =
-        if checked
-          lineSource.replace(@incompletePattern, @complete)
-        else
-          lineSource.replace(@completePattern, @incomplete)
-
-      result[lineNumber - 1] = line
-    else
-      clean = source.replace(/\r/g, '').
-        replace(@itemsInParasPattern, '').
-        split("\n")
-      index = 0
-      inCodeBlock = false
-
-      result = for line, i in split_source
-        if inCodeBlock
-          # Lines inside of a code block are ignored.
-          if line.match(@endFencesPattern)
-            # Stop ignoring lines once the code block is closed.
-            inCodeBlock = false
-        else if line.match(@startFencesPattern)
-          # Start ignoring lines inside a code block.
-          inCodeBlock = true
-        else if line in clean && line.trim().match(@itemPattern)
-          index += 1
-          if index == itemIndex
-            lineNumber = i + 1
-            lineSource = line
-            line =
-              if checked
-                line.replace(@incompletePattern, @complete)
-              else
-                line.replace(@completePattern, @incomplete)
-        line
+    result = for line, i in split_source
+      if inCodeBlock
+        # Lines inside of a code block are ignored.
+        if line.match(@endFencesPattern)
+          # Stop ignoring lines once the code block is closed.
+          inCodeBlock = false
+      else if line.match(@startFencesPattern)
+        # Start ignoring lines inside a code block.
+        inCodeBlock = true
+      else if line in clean && line.trim().match(@itemPattern)
+        index += 1
+        if index == itemIndex
+          lineNumber = i + 1
+          lineSource = line
+          line =
+            if checked
+              line.replace(@incompletePattern, @complete)
+            else
+              line.replace(@completePattern, @incomplete)
+      line
 
     return {
       result: result.join("\n")

--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -150,7 +150,7 @@ class TaskList
 
     unless changeEvent.defaultPrevented
       { result, lineNumber, lineSource } =
-        TaskList.updateSource(@field.value, index, item.checked)
+        TaskList.updateSource(@field.value, index, item)
 
       @field.value = result
       changeEvent = createEvent 'change'
@@ -220,35 +220,55 @@ class TaskList
   # given checked value.
   #
   # Returns the updated String text.
-  @updateSource: (source, itemIndex, checked) ->
-    clean = source.replace(/\r/g, '').
-      replace(@itemsInParasPattern, '').
-      split("\n")
-    index = 0
-    inCodeBlock = false
+  @updateSource: (source, itemIndex, item) ->
+    checked = item.checked
+    split_source = source.split("\n")
+    sourcepos = item.parentElement.getAttribute('data-sourcepos')
     lineNumber
     lineSource
 
-    result = for line, i in source.split("\n")
-      if inCodeBlock
-        # Lines inside of a code block are ignored.
-        if line.match(@endFencesPattern)
-          # Stop ignoring lines once the code block is closed.
-          inCodeBlock = false
-      else if line.match(@startFencesPattern)
-        # Start ignoring lines inside a code block.
-        inCodeBlock = true
-      else if line in clean && line.trim().match(@itemPattern)
-        index += 1
-        if index == itemIndex
-          lineNumber = i + 1
-          lineSource = line
-          line =
-            if checked
-              line.replace(@incompletePattern, @complete)
-            else
-              line.replace(@completePattern, @incomplete)
-      line
+    if sourcepos
+      # If we have sourcepos information, that tells us
+      # which line the task is on without the need for parsing
+      result = split_source
+      lineNumber = parseInt(sourcepos.split(":")[0])
+      lineSource = result[lineNumber - 1]
+
+      line =
+        if checked
+          lineSource.replace(@incompletePattern, @complete)
+        else
+          lineSource.replace(@completePattern, @incomplete)
+
+      result[lineNumber - 1] = line
+    else
+      clean = source.replace(/\r/g, '').
+        replace(@itemsInParasPattern, '').
+        split("\n")
+      index = 0
+      inCodeBlock = false
+
+      result = for line, i in split_source
+        if inCodeBlock
+          # Lines inside of a code block are ignored.
+          if line.match(@endFencesPattern)
+            # Stop ignoring lines once the code block is closed.
+            inCodeBlock = false
+        else if line.match(@startFencesPattern)
+          # Start ignoring lines inside a code block.
+          inCodeBlock = true
+        else if line in clean && line.trim().match(@itemPattern)
+          index += 1
+          if index == itemIndex
+            lineNumber = i + 1
+            lineSource = line
+            line =
+              if checked
+                line.replace(@incompletePattern, @complete)
+              else
+                line.replace(@completePattern, @incomplete)
+        line
+
     return {
       result: result.join("\n")
       lineNumber: lineNumber

--- a/test/functional/test_task_lists_behavior.html
+++ b/test/functional/test_task_lists_behavior.html
@@ -71,6 +71,7 @@
 </head>
 <body>
   <div class="js-task-list-container js-task-list-enable">
+    <h2>Using Regex Parsing</h2>
     <div class="markdown">
       <ul class="task-list">
         <li>
@@ -89,6 +90,41 @@
           completed, lower
         </li>
         <li class="task-list-item">
+          <input type="checkbox" class="task-list-item-checkbox" disabled checked />
+          completed capitalized
+        </li>
+      </ul>
+    </div>
+    <form action="/update" method="POST" data-remote data-type="json">
+      <textarea name="comment[body]" class="js-task-list-field" cols="40" rows="10">
+- [ ]  
+- [ ] I'm a task list item
+- [ ] with non-breaking space
+- [x] completed, lower
+- [X] completed capitalized</textarea>
+    </form>
+  </div>
+
+  <div class="js-task-list-container js-task-list-enable">
+    <h2>Using CommonMark Source Positioning</h2>
+    <div class="markdown">
+      <ul class="task-list" data-sourcepos="1:1-5:27">
+        <li data-sourcepos="1:1-1:8">
+          [ ]
+        </li>
+        <li class="task-list-item" data-sourcepos="2:1-2:26">
+          <input type="checkbox" class="task-list-item-checkbox" disabled />
+          I'm a task list item
+        </li>
+        <li class="task-list-item" data-sourcepos="3:1-3:30">
+          <input type="checkbox" class="task-list-item-checkbox" disabled />
+          with non-breaking space
+        </li>
+        <li class="task-list-item" data-sourcepos="4:1-4:22">
+          <input type="checkbox" class="task-list-item-checkbox" disabled checked />
+          completed, lower
+        </li>
+        <li class="task-list-item" data-sourcepos="5:1-5:27">
           <input type="checkbox" class="task-list-item-checkbox" disabled checked />
           completed capitalized
         </li>

--- a/test/unit/test_updates.coffee
+++ b/test/unit/test_updates.coffee
@@ -260,92 +260,162 @@ QUnit.module "TaskList updates",
     $('#qunit-fixture').append(@container)
     @container.taskList()
 
+    @setSourcePosition = (item, pos) =>
+      item.attr('data-sourcepos', pos)
+
+    @onChanged = (assert) =>
+      utils =
+      test: (fn) =>
+        done = assert.async()
+        @field.on 'tasklist:changed', (event) =>
+          fn event
+          done()
+      eventHas: (name, value) =>
+        utils.test (event) =>
+          assert.equal event.detail[name], value
+      fieldIs: (value) =>
+        utils.test () =>
+          assert.equal @field.val(), value
+
   afterEach: ->
     $(document).off 'tasklist:changed'
 
-assertTaskComplete =(assert, field, changes, taskItem, taskCheckbox, sourcepos) ->
-  done = assert.async()
-  assert.expect 3
-
-  taskItem.attr('data-sourcepos', sourcepos) if sourcepos
-
-  field.on 'tasklist:changed', (event) =>
-    assert.ok event.detail.checked
-    assert.equal event.detail.index, taskItem.expectedIndex
-    assert.equal field.val(), changes
-    done()
-
-  taskCheckbox.click()
-
-assertTaskIncomplete =(assert, field, changes, taskItem, taskCheckbox, sourcepos) ->
-  done = assert.async()
-  assert.expect 3
-
-  taskItem.attr('data-sourcepos', sourcepos) if sourcepos
-
-  field.on 'tasklist:changed', (event) =>
-    assert.ok !event.detail.checked
-    assert.equal event.detail.index, taskItem.expectedIndex
-    assert.equal field.val(), changes
-    done()
-
-  taskCheckbox.click()
-
 QUnit.test "updates the source, marking the incomplete item as complete", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toIncomplete, @incompleteItem, @incompleteCheckbox, null)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @incompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toIncomplete)
+
+  @incompleteCheckbox.click()
 
 QUnit.test "updates the source, marking the incomplete item as complete (sourcepos)", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toIncomplete, @incompleteItem, @incompleteCheckbox, @incompleteItemSourcePos)
+  @setSourcePosition(@incompleteItem, @incompleteItemSourcePos)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @incompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toIncomplete)
+
+  @incompleteCheckbox.click()
 
 QUnit.test "updates the source, marking the complete item as incomplete", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toComplete, @completeItem, @completeCheckbox, null)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @completeItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toComplete)
+
+  @completeCheckbox.click()
 
 QUnit.test "updates the source, marking the complete item as incomplete (sourcepos)", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toComplete, @completeItem, @completeCheckbox, @completeItemSourcePos)
+  @setSourcePosition(@completeItem, @completeItemSourcePos)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @completeItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toComplete)
+
+  @completeCheckbox.click()
 
 # See: https://github.com/github/task-lists/pull/14
 QUnit.test "updates the source for items with non-breaking spaces", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toIncompleteNBSP, @incompleteNBSPItem, @incompleteNBSPCheckbox, null)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @incompleteNBSPItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toIncompleteNBSP)
+
+  @incompleteNBSPCheckbox.click()
 
 # See: https://github.com/github/task-lists/pull/14
 QUnit.test "updates the source for items with non-breaking spaces (sourcepos)", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toIncompleteNBSP, @incompleteNBSPItem, @incompleteNBSPCheckbox, @incompleteNBSPItemSourcePos)
+  @setSourcePosition(@incompleteNBSPItem, @incompleteNBSPItemSourcePos)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @incompleteNBSPItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toIncompleteNBSP)
+
+  @incompleteNBSPCheckbox.click()
 
 QUnit.test "updates the source of a quoted item, marking the incomplete item as complete", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toQuotedIncomplete, @quotedIncompleteItem, @quotedIncompleteCheckbox, null)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @quotedIncompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toQuotedIncomplete)
+
+  @quotedIncompleteCheckbox.click()
 
 QUnit.test "updates the source of a quoted item, marking the incomplete item as complete (sourcepos)", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toQuotedIncomplete, @quotedIncompleteItem, @quotedIncompleteCheckbox, @quotedIncompleteItemSourcePos)
+  @setSourcePosition(@quotedIncompleteItem, @quotedIncompleteItemSourcePos)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @quotedIncompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toQuotedIncomplete)
+
+  @quotedIncompleteCheckbox.click()
 
 QUnit.test "updates the source of a quoted item, marking the complete item as incomplete", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toQuotedComplete, @quotedCompleteItem, @quotedCompleteCheckbox, null)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @quotedCompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toQuotedComplete)
+
+  @quotedCompleteCheckbox.click()
 
 QUnit.test "updates the source of a quoted item, marking the complete item as incomplete (sourcepos)", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toQuotedComplete, @quotedCompleteItem, @quotedCompleteCheckbox, @quotedCompleteItemSourcePos)
+  @setSourcePosition(@quotedCompleteItem, @quotedCompleteItemSourcePos)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @quotedCompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toQuotedComplete)
+
+  @quotedCompleteCheckbox.click()
 
 QUnit.test "updates the source of a quoted quoted item, marking the incomplete item as complete", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toInnerIncomplete, @innerIncompleteItem, @innerIncompleteCheckbox, null)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @innerIncompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toInnerIncomplete)
+
+  @innerIncompleteCheckbox.click()
 
 QUnit.test "updates the source of a quoted quoted item, marking the incomplete item as complete (sourcepos)", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toInnerIncomplete, @innerIncompleteItem, @innerIncompleteCheckbox, @innerIncompleteItemSourcePos)
+  @setSourcePosition(@innerIncompleteItem, @innerIncompleteItemSourcePos)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @innerIncompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toInnerIncomplete)
+
+  @innerIncompleteCheckbox.click()
 
 QUnit.test "updates the source of a quoted quoted item, marking the complete item as incomplete", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toInnerComplete, @innerCompleteItem, @innerCompleteCheckbox, null)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @innerCompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toInnerComplete)
+
+  @innerCompleteCheckbox.click()
 
 QUnit.test "updates the source of a quoted quoted item, marking the complete item as incomplete (sourcepos)", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toInnerComplete, @innerCompleteItem, @innerCompleteCheckbox, @innerCompleteItemSourcePos)
+  @setSourcePosition(@innerCompleteItem, @innerCompleteItemSourcePos)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @innerCompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toInnerComplete)
+
+  @innerCompleteCheckbox.click()
 
 QUnit.test "updates the source of an ordered list item, marking the incomplete item as complete", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toOrderedIncomplete, @orderedIncompleteItem, @orderedIncompleteCheckbox, null)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @orderedIncompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toOrderedIncomplete)
+
+  @orderedIncompleteCheckbox.click()
 
 QUnit.test "updates the source of an ordered list item, marking the incomplete item as complete (sourcepos)", (assert) ->
-  assertTaskComplete(assert, @field, @changes.toOrderedIncomplete, @orderedIncompleteItem, @orderedIncompleteCheckbox, @orderedIncompleteItemSourcePos)
+  @setSourcePosition(@orderedIncompleteItem, @orderedIncompleteItemSourcePos)
+  @onChanged(assert).eventHas('checked', true)
+  @onChanged(assert).eventHas('index', @orderedIncompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toOrderedIncomplete)
+
+  @orderedIncompleteCheckbox.click()
 
 QUnit.test "updates the source of an ordered list item, marking the complete item as incomplete", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toOrderedComplete, @orderedCompleteItem, @orderedCompleteCheckbox, null)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @orderedCompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toOrderedComplete)
+
+  @orderedCompleteCheckbox.click()
 
 QUnit.test "updates the source of an ordered list item, marking the complete item as incomplete (sourcepos)", (assert) ->
-  assertTaskIncomplete(assert, @field, @changes.toOrderedComplete, @orderedCompleteItem, @orderedCompleteCheckbox, @orderedCompleteItemSourcePos)
+  @setSourcePosition(@orderedCompleteItem, @orderedCompleteItemSourcePos)
+  @onChanged(assert).eventHas('checked', false)
+  @onChanged(assert).eventHas('index', @orderedCompleteItem.expectedIndex)
+  @onChanged(assert).fieldIs(@changes.toOrderedComplete)
+
+  @orderedCompleteCheckbox.click()
 
 QUnit.test "update ignores items that look like Task List items but lack list prefix", (assert) ->
   assertItemsLackListPrefix(assert, null, null)

--- a/test/unit/test_updates.coffee
+++ b/test/unit/test_updates.coffee
@@ -247,122 +247,113 @@ QUnit.module "TaskList updates",
 
     @blockquote.append @field
 
+    @completeItemSourcePos = '1:1-1:14'
+    @incompleteItemSourcePos = '2:1-2:16'
+    @incompleteNBSPItemSourcePos = '3:1-3:27'
+    @quotedCompleteItemSourcePos = '4:3-4:23'
+    @quotedIncompleteItemSourcePos = '5:3-5:25'
+    @innerCompleteItemSourcePos = '6:4-6:23'
+    @innerIncompleteItemSourcePos = '7:5-7:26'
+    @orderedCompleteItemSourcePos = '8:3-8:25'
+    @orderedIncompleteItemSourcePos = '9:3-9:27'
+
     $('#qunit-fixture').append(@container)
     @container.taskList()
 
   afterEach: ->
     $(document).off 'tasklist:changed'
 
-QUnit.test "updates the source, marking the incomplete item as complete", (assert) ->
+assertTaskComplete =(assert, field, changes, taskItem, taskCheckbox, sourcepos) ->
   done = assert.async()
   assert.expect 3
 
-  @field.on 'tasklist:changed', (event) =>
+  taskItem.attr('data-sourcepos', sourcepos) if sourcepos
+
+  field.on 'tasklist:changed', (event) =>
     assert.ok event.detail.checked
-    assert.equal event.detail.index, @incompleteItem.expectedIndex
-    assert.equal @field.val(), @changes.toIncomplete
+    assert.equal event.detail.index, taskItem.expectedIndex
+    assert.equal field.val(), changes
     done()
 
-  @incompleteCheckbox.click()
+  taskCheckbox.click()
+
+assertTaskIncomplete =(assert, field, changes, taskItem, taskCheckbox, sourcepos) ->
+  done = assert.async()
+  assert.expect 3
+
+  taskItem.attr('data-sourcepos', sourcepos) if sourcepos
+
+  field.on 'tasklist:changed', (event) =>
+    assert.ok !event.detail.checked
+    assert.equal event.detail.index, taskItem.expectedIndex
+    assert.equal field.val(), changes
+    done()
+
+  taskCheckbox.click()
+
+QUnit.test "updates the source, marking the incomplete item as complete", (assert) ->
+  assertTaskComplete(assert, @field, @changes.toIncomplete, @incompleteItem, @incompleteCheckbox, null)
+
+QUnit.test "updates the source, marking the incomplete item as complete (sourcepos)", (assert) ->
+  assertTaskComplete(assert, @field, @changes.toIncomplete, @incompleteItem, @incompleteCheckbox, @incompleteItemSourcePos)
 
 QUnit.test "updates the source, marking the complete item as incomplete", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskIncomplete(assert, @field, @changes.toComplete, @completeItem, @completeCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok !event.detail.checked
-    assert.equal event.detail.index, @completeItem.expectedIndex
-    assert.equal @field.val(), @changes.toComplete
-    done()
-
-  @completeCheckbox.click()
+QUnit.test "updates the source, marking the complete item as incomplete (sourcepos)", (assert) ->
+  assertTaskIncomplete(assert, @field, @changes.toComplete, @completeItem, @completeCheckbox, @completeItemSourcePos)
 
 # See: https://github.com/github/task-lists/pull/14
 QUnit.test "updates the source for items with non-breaking spaces", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskComplete(assert, @field, @changes.toIncompleteNBSP, @incompleteNBSPItem, @incompleteNBSPCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok event.detail.checked
-    assert.equal event.detail.index, @incompleteNBSPItem.expectedIndex
-    assert.equal @field.val(), @changes.toIncompleteNBSP
-    done()
-
-  @incompleteNBSPCheckbox.click()
+# See: https://github.com/github/task-lists/pull/14
+QUnit.test "updates the source for items with non-breaking spaces (sourcepos)", (assert) ->
+  assertTaskComplete(assert, @field, @changes.toIncompleteNBSP, @incompleteNBSPItem, @incompleteNBSPCheckbox, @incompleteNBSPItemSourcePos)
 
 QUnit.test "updates the source of a quoted item, marking the incomplete item as complete", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskComplete(assert, @field, @changes.toQuotedIncomplete, @quotedIncompleteItem, @quotedIncompleteCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok event.detail.checked
-    assert.equal event.detail.index, @quotedIncompleteItem.expectedIndex
-    assert.equal @field.val(), @changes.toQuotedIncomplete
-    done()
-
-  @quotedIncompleteCheckbox.click()
+QUnit.test "updates the source of a quoted item, marking the incomplete item as complete (sourcepos)", (assert) ->
+  assertTaskComplete(assert, @field, @changes.toQuotedIncomplete, @quotedIncompleteItem, @quotedIncompleteCheckbox, @quotedIncompleteItemSourcePos)
 
 QUnit.test "updates the source of a quoted item, marking the complete item as incomplete", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskIncomplete(assert, @field, @changes.toQuotedComplete, @quotedCompleteItem, @quotedCompleteCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok !event.detail.checked
-    assert.equal event.detail.index, @quotedCompleteItem.expectedIndex
-    assert.equal @field.val(), @changes.toQuotedComplete
-    done()
-
-  @quotedCompleteCheckbox.click()
+QUnit.test "updates the source of a quoted item, marking the complete item as incomplete (sourcepos)", (assert) ->
+  assertTaskIncomplete(assert, @field, @changes.toQuotedComplete, @quotedCompleteItem, @quotedCompleteCheckbox, @quotedCompleteItemSourcePos)
 
 QUnit.test "updates the source of a quoted quoted item, marking the incomplete item as complete", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskComplete(assert, @field, @changes.toInnerIncomplete, @innerIncompleteItem, @innerIncompleteCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok event.detail.checked
-    assert.equal event.detail.index, @innerIncompleteItem.expectedIndex
-    assert.equal @field.val(), @changes.toInnerIncomplete
-    done()
-
-  @innerIncompleteCheckbox.click()
+QUnit.test "updates the source of a quoted quoted item, marking the incomplete item as complete (sourcepos)", (assert) ->
+  assertTaskComplete(assert, @field, @changes.toInnerIncomplete, @innerIncompleteItem, @innerIncompleteCheckbox, @innerIncompleteItemSourcePos)
 
 QUnit.test "updates the source of a quoted quoted item, marking the complete item as incomplete", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskIncomplete(assert, @field, @changes.toInnerComplete, @innerCompleteItem, @innerCompleteCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok !event.detail.checked
-    assert.equal event.detail.index, @innerCompleteItem.expectedIndex
-    assert.equal @field.val(), @changes.toInnerComplete
-    done()
-
-  @innerCompleteCheckbox.click()
+QUnit.test "updates the source of a quoted quoted item, marking the complete item as incomplete (sourcepos)", (assert) ->
+  assertTaskIncomplete(assert, @field, @changes.toInnerComplete, @innerCompleteItem, @innerCompleteCheckbox, @innerCompleteItemSourcePos)
 
 QUnit.test "updates the source of an ordered list item, marking the incomplete item as complete", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskComplete(assert, @field, @changes.toOrderedIncomplete, @orderedIncompleteItem, @orderedIncompleteCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok event.detail.checked
-    assert.equal event.detail.index, @orderedIncompleteItem.expectedIndex
-    assert.equal @field.val(), @changes.toOrderedIncomplete
-    done()
-
-  @orderedIncompleteCheckbox.click()
+QUnit.test "updates the source of an ordered list item, marking the incomplete item as complete (sourcepos)", (assert) ->
+  assertTaskComplete(assert, @field, @changes.toOrderedIncomplete, @orderedIncompleteItem, @orderedIncompleteCheckbox, @orderedIncompleteItemSourcePos)
 
 QUnit.test "updates the source of an ordered list item, marking the complete item as incomplete", (assert) ->
-  done = assert.async()
-  assert.expect 3
+  assertTaskIncomplete(assert, @field, @changes.toOrderedComplete, @orderedCompleteItem, @orderedCompleteCheckbox, null)
 
-  @field.on 'tasklist:changed', (event) =>
-    assert.ok !event.detail.checked
-    assert.equal event.detail.index, @orderedCompleteItem.expectedIndex
-    assert.equal @field.val(), @changes.toOrderedComplete
-    done()
-
-  @orderedCompleteCheckbox.click()
+QUnit.test "updates the source of an ordered list item, marking the complete item as incomplete (sourcepos)", (assert) ->
+  assertTaskIncomplete(assert, @field, @changes.toOrderedComplete, @orderedCompleteItem, @orderedCompleteCheckbox, @orderedCompleteItemSourcePos)
 
 QUnit.test "update ignores items that look like Task List items but lack list prefix", (assert) ->
+  assertItemsLackListPrefix(assert, null, null)
+
+QUnit.test "update ignores items that look like Task List items but lack list prefix (sourcepos)", (assert) ->
+  assertItemsLackListPrefix(assert, '3:1-3:11', '4:1-4:10')
+
+assertItemsLackListPrefix =(assert, sourcepos1, sourcepos2) ->
   done = assert.async()
   assert.expect 3
 
@@ -373,6 +364,7 @@ QUnit.test "update ignores items that look like Task List items but lack list pr
   list = $ '<ul>', class: 'task-list'
 
   item1 = $ '<li>', class: 'task-list-item'
+  item1.attr('data-sourcepos', sourcepos1) if sourcepos1
   item1Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'
@@ -380,6 +372,7 @@ QUnit.test "update ignores items that look like Task List items but lack list pr
     checked: false
 
   item2 = $ '<li>', class: 'task-list-item'
+  item2.attr('data-sourcepos', sourcepos2) if sourcepos2
   item2Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'
@@ -423,6 +416,12 @@ QUnit.test "update ignores items that look like Task List items but lack list pr
   item2Checkbox.click()
 
 QUnit.test "update ignores items that look like Task List items but are links", (assert) ->
+  assertItemsButAreLinks(assert, null, null)
+
+QUnit.test "update ignores items that look like Task List items but are links (sourcepos)", (assert) ->
+  assertItemsButAreLinks(assert, '5:1-5:24', '6:1-6:10')
+
+assertItemsButAreLinks =(assert, sourcepos1, sourcepos2) ->
   done = assert.async()
   assert.expect 3
 
@@ -433,6 +432,7 @@ QUnit.test "update ignores items that look like Task List items but are links", 
   list = $ '<ul>', class: 'task-list'
 
   item1 = $ '<li>', class: 'task-list-item'
+  item1.attr('data-sourcepos', sourcepos1) if sourcepos1
   item1Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'
@@ -440,6 +440,7 @@ QUnit.test "update ignores items that look like Task List items but are links", 
     checked: false
 
   item2 = $ '<li>', class: 'task-list-item'
+  item2.attr('data-sourcepos', sourcepos2) if sourcepos2
   item2Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'
@@ -487,6 +488,12 @@ QUnit.test "update ignores items that look like Task List items but are links", 
   item2Checkbox.click()
 
 QUnit.test "updates items followed by links", (assert) ->
+  assertItemsFollowedByLinks(assert, null, null)
+
+QUnit.test "updates items followed by links (sourcepos)", (assert) ->
+  assertItemsFollowedByLinks(assert, '1:1-1:24', '2:1-3:0')
+
+assertItemsFollowedByLinks =(assert, sourcepos1, sourcepos2) ->
   done = assert.async()
   assert.expect 3
 
@@ -497,6 +504,7 @@ QUnit.test "updates items followed by links", (assert) ->
   list = $ '<ul>', class: 'task-list'
 
   item1 = $ '<li>', class: 'task-list-item'
+  item1.attr('data-sourcepos', sourcepos1) if sourcepos1
   item1Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'
@@ -504,6 +512,7 @@ QUnit.test "updates items followed by links", (assert) ->
     checked: false
 
   item2 = $ '<li>', class: 'task-list-item'
+  item2.attr('data-sourcepos', sourcepos2) if sourcepos2
   item2Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'
@@ -544,6 +553,12 @@ QUnit.test "updates items followed by links", (assert) ->
 
 # See https://github.com/deckar01/task_list/issues/3
 QUnit.test "doesn't update items inside code blocks", (assert) ->
+  assertItemsInsideCodeBlocks(assert, null, null)
+
+QUnit.test "doesn't update items inside code blocks (sourcepos)", (assert) ->
+  assertItemsInsideCodeBlocks(assert, '6:1-6:11', '7:1-7:11')
+
+assertItemsInsideCodeBlocks =(assert, sourcepos1, sourcepos2) ->
   done = assert.async()
   assert.expect 3
 
@@ -552,6 +567,7 @@ QUnit.test "doesn't update items inside code blocks", (assert) ->
   list = $ '<ul>', class: 'task-list'
 
   item1 = $ '<li>', class: 'task-list-item'
+  item1.attr('data-sourcepos', sourcepos1) if sourcepos1
   item1Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'
@@ -559,6 +575,7 @@ QUnit.test "doesn't update items inside code blocks", (assert) ->
     checked: false
 
   item2 = $ '<li>', class: 'task-list-item'
+  item2.attr('data-sourcepos', sourcepos2) if sourcepos2
   item2Checkbox = $ '<input>',
     type: 'checkbox'
     class: 'task-list-item-checkbox'


### PR DESCRIPTION
@deckar01 this adds support for detecting and using the `sourcepos` information if it's available.  This allow us to avoid the regex parsing when possible.

I attempted to DRY up the tests, as I hated to duplicate all of them.  Let me know if you want a different style or format.
